### PR TITLE
Load OpenAI API key from dotenv file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copie este arquivo para .env e preencha com sua chave da OpenAI.
+OPENAI_API_KEY=coloque_sua_chave_aqui

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# ia-vibecode-agente-mudanca 1
+# ia-vibecode-agente-mudanca
+
+Este projeto demonstra como carregar perfis de cidades a partir de um arquivo CSV e, agora, como expor esses dados como uma tool simples do LangChain que utiliza os modelos da OpenAI.
+
+## Configuração do ambiente Python
+
+1. Crie e ative um ambiente virtual (requer Python 3.10 ou superior):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+2. Instale as dependências:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Copie o arquivo de exemplo `.env.example` para `.env` e edite-o informando sua chave da OpenAI:
+
+   ```bash
+   cp .env.example .env
+   # edite o arquivo .env e substitua pelo valor da sua chave
+   ```
+
+   > O script `run_langchain_agent.py` carregará automaticamente o arquivo `.env`
+   > (via `python-dotenv`) antes de inicializar o modelo da OpenAI.
+
+## Executando o agente LangChain
+
+Após configurar o ambiente, execute o agente que utiliza a tool `listar_perfis_cidades`:
+
+```bash
+python run_langchain_agent.py
+```
+
+O agente utiliza o modelo `gpt-3.5-turbo` (via `ChatOpenAI`) para responder perguntas e, quando necessário, consulta a tool para obter a lista de cidades disponíveis.

--- a/langchain_city_tool.py
+++ b/langchain_city_tool.py
@@ -1,0 +1,37 @@
+"""LangChain tool for accessing city profile data."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from langchain.tools import tool
+
+from city_profiles import CityProfile, load_cities
+
+
+def _format_city(profile: CityProfile) -> str:
+    """Convert a :class:`CityProfile` into a readable summary string."""
+    return (
+        f"{profile.city}, {profile.state} | "
+        f"Distância: {profile.distance_km_from_home} km | "
+        f"Clima: {profile.climate_summary} | "
+        f"Notas: {profile.notes}"
+    )
+
+
+def _summarise_cities(cities: Iterable[CityProfile]) -> str:
+    lines = ["Perfis de cidades disponíveis:"]
+    for profile in cities:
+        lines.append(_format_city(profile))
+    return "\n".join(lines)
+
+
+@tool("listar_perfis_cidades")
+def listar_perfis_cidades(_: str = "") -> str:
+    """Retorna um resumo dos perfis de cidades disponíveis no dataset."""
+    cities = load_cities()
+    if not cities:
+        return "Nenhum perfil de cidade encontrado."
+    return _summarise_cities(cities)
+
+
+__all__ = ["listar_perfis_cidades"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langchain>=0.1.0
+langchain-openai>=0.1.0
+python-dotenv>=1.0.0

--- a/run_langchain_agent.py
+++ b/run_langchain_agent.py
@@ -1,0 +1,38 @@
+"""Exemplo simples de uso do LangChain com a tool de cidades."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from langchain.agents import AgentType, initialize_agent
+from langchain_openai import ChatOpenAI
+
+from langchain_city_tool import listar_perfis_cidades
+
+
+def main() -> None:
+    """Executa um agente LangChain utilizando o modelo da OpenAI."""
+    load_dotenv(dotenv_path=Path.cwd() / ".env")
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    if not openai_api_key:
+        raise RuntimeError(
+            "Defina a variável OPENAI_API_KEY em um arquivo .env ou no ambiente."
+        )
+    llm = ChatOpenAI(
+        model="gpt-3.5-turbo",
+        temperature=0,
+        openai_api_key=openai_api_key,
+    )
+    agent = initialize_agent(
+        tools=[listar_perfis_cidades],
+        llm=llm,
+        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+        verbose=True,
+    )
+    resposta = agent.run("Quais cidades estão disponíveis?")
+    print("\nResposta do agente:\n", resposta)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a LangChain tool que expõe os perfis de cidades existentes
- criar um exemplo simples de agente usando ChatOpenAI e a tool de cidades
- documentar configuração com venv, variável OPENAI_API_KEY e dependências
- adicionar `.env.example`, carregar a chave da OpenAI com `python-dotenv` e repassar explicitamente ao agente

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc7f60e0c8324b9afb5bace433607