### PR TITLE
Integrate LangSmith tracing into agent run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 langchain>=0.1.0
 langchain-openai>=0.1.0
+langsmith>=0.1.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- add the langsmith dependency to the project requirements
- configure the LangChain agent run to register LangSmith tracing metadata when enabled
- propagate tracing callbacks to the route analysis chain for consistent logging

## Testing
- python run_langchain_agent.py *(fails: missing OPENAI_API_KEY in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de612218a08324978b0ce2d80906af